### PR TITLE
[56] add line spacing to title textviews

### DIFF
--- a/Sources/NiceComponents/Title/ItemTitle.swift
+++ b/Sources/NiceComponents/Title/ItemTitle.swift
@@ -42,6 +42,7 @@ public struct ItemTitle: NiceText {
             )
             .fixedSize(horizontal: false, vertical: true)
             .lineLimit(style.lineLimit)
+            .lineSpacing(style.lineSpacing)
     }
 }
 

--- a/Sources/NiceComponents/Title/ScreenTitle.swift
+++ b/Sources/NiceComponents/Title/ScreenTitle.swift
@@ -41,6 +41,7 @@ public struct ScreenTitle: NiceText {
             )
             .fixedSize(horizontal: false, vertical: true)
             .lineLimit(style.lineLimit)
+            .lineSpacing(style.lineSpacing)
     }
 }
 

--- a/Sources/NiceComponents/Title/SectionTitle.swift
+++ b/Sources/NiceComponents/Title/SectionTitle.swift
@@ -41,6 +41,7 @@ public struct SectionTitle: NiceText {
             )
             .fixedSize(horizontal: false, vertical: true)
             .lineLimit(style.lineLimit)
+            .lineSpacing(style.lineSpacing)
     }
 }
 


### PR DESCRIPTION
Fixes #56 

The title components weren't tracking the line spacing specified in NiceTextStyle, this just adds that line