### PR TITLE
Replace hand written initializers and copy functions with macros generated ones

### DIFF
--- a/NiceComponentsExample/NiceComponentsExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NiceComponentsExample/NiceComponentsExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "c1f60c63f356d364f4284ba82961acbe7de79bcc",
           "version": "7.8.1"
         }
+      },
+      {
+        "package": "swift-syntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "state": {
+          "branch": null,
+          "revision": "64889f0c732f210a935a0ad7cda38f77f876262d",
+          "version": "509.1.1"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -1,26 +1,46 @@
-// swift-tools-version:5.3
+// swift-tools-version: 5.9
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "NiceComponents",
     platforms: [
-        .iOS("15.0"),
+        .iOS(.v15),
         .macOS(.v10_15)
     ],
     products: [
         .library(
             name: "NiceComponents",
             targets: ["NiceComponents"]),
+        .library(
+            name: "NiceInit",
+            targets: ["NiceInit"]
+        ),
     ],
     dependencies: [
         .package(
             url: "https://github.com/onevcat/Kingfisher.git",
             from: "7.6.1"
-        )
+        ),
+        .package(
+            url: "https://github.com/apple/swift-syntax.git",
+            from: "509.0.0"
+        ),
     ],
     targets: [
+        .macro(
+            name: "NiceInitMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
+
+        .target(name: "NiceInit", dependencies: ["NiceInitMacros"]),
+
         .target(
             name: "NiceComponents",
-            dependencies: ["Kingfisher"]),
+            dependencies: ["Kingfisher", "NiceInit"]),
+
     ]
 )

--- a/Sources/NiceComponents/Button/NiceButton.swift
+++ b/Sources/NiceComponents/Button/NiceButton.swift
@@ -141,7 +141,7 @@ extension NiceButton {
         .frame(height: style.height)
         .fixedSize(horizontal: false, vertical: true)
         .background(inactive ? style.inactiveSurfaceColor : style.surfaceColor)
-        .cornerRadius(cornerRadius)
+        .cornerRadius(style.border.cornerRadius)
         .overlay(
             style.borderOverlay
         )

--- a/Sources/NiceComponents/Text/NiceText.swift
+++ b/Sources/NiceComponents/Text/NiceText.swift
@@ -49,9 +49,8 @@ public extension NiceText {
             text,
             style: Self.defaultStyle.with(
                 color: color,
-                size: size,
-                lineLimit: lineLimit,
-                dynamicTypeMaxSize: dynamicMaxSize
+                fontStyle: Self.defaultStyle.fontStyle.with(size: size, dynamicTypeMaxSize: dynamicMaxSize),
+                lineLimit: lineLimit
             )
         )
     }
@@ -90,10 +89,10 @@ public extension NiceText {
         configure(&attributedString)
         self.init(attributedString, style: Self.defaultStyle.with(
             color: color,
-            size: size,
-            lineLimit: lineLimit,
-            dynamicTypeMaxSize: dynamicMaxSize
-        ))
+            fontStyle: Self.defaultStyle.fontStyle.with(size: size, dynamicTypeMaxSize: dynamicMaxSize),
+            lineLimit: lineLimit
+        )
+)
     }
 }
 

--- a/Sources/NiceComponents/Theme/ColorTheme.swift
+++ b/Sources/NiceComponents/Theme/ColorTheme.swift
@@ -13,42 +13,42 @@ import NiceInit
 /// The language and structure used here is heavily influenced by the [Material Design color system](https://m2.material.io/design/color/the-color-system.html).
 @NiceInit public struct ColorTheme {
     /// The color most frequently displayed across components.
-    @Asset public var primary: Color
+    @NiceAsset public var primary: Color
 
     /// An optional variant, or shade, of your primary color.
-    @Asset public var primaryVariant: Color
+    @NiceAsset public var primaryVariant: Color
 
     /// The color elements presented on top of primary colors should use.
-    @Asset public var onPrimary: Color
+    @NiceAsset public var onPrimary: Color
 
     /// An alternate theme color, complimentary to the primary color.
-    @Asset public var secondary: Color
+    @NiceAsset public var secondary: Color
 
     /// An optional variant of the secondary theme color.
-    @Asset public var secondaryVariant: Color
+    @NiceAsset public var secondaryVariant: Color
 
     /// The color elements presented on top of secondary colors should use.
-    @Asset public var onSecondary: Color
+    @NiceAsset public var onSecondary: Color
 
     /// The color that should appear behind scrollable content within the app.
-    @Asset public var background: Color
+    @NiceAsset public var background: Color
 
     /// The color elements presented on top of a background should use.
-    @Asset public var onBackground: Color
+    @NiceAsset public var onBackground: Color
 
     /// The color used to indicate errors in components.
-    @Asset public var error: Color
+    @NiceAsset public var error: Color
 
     /// The color elements presented on top of errors should use.
-    @Asset public var onError: Color
+    @NiceAsset public var onError: Color
 
     /// The color used for background colors in components, such as sheets, cards and menus.
-    @Asset public var surface: Color
+    @NiceAsset public var surface: Color
 
     /// The color elements presented on top of a surfaces should use.
-    @Asset public var onSurface: Color
+    @NiceAsset public var onSurface: Color
 
     /// The color used for drop shadows.
-    @Asset public var shadow: Color
+    @NiceAsset public var shadow: Color
 
 }

--- a/Sources/NiceComponents/Theme/ColorTheme.swift
+++ b/Sources/NiceComponents/Theme/ColorTheme.swift
@@ -7,100 +7,48 @@
 //
 
 import SwiftUI
+import NiceInit
 
 /// A collection of styling settings for colors, used across components
 /// The language and structure used here is heavily influenced by the [Material Design color system](https://m2.material.io/design/color/the-color-system.html).
-public struct ColorTheme {
+@NiceInit public struct ColorTheme {
     /// The color most frequently displayed across components.
-    public var primary: Color
+    @Asset public var primary: Color
 
     /// An optional variant, or shade, of your primary color.
-    public var primaryVariant: Color
+    @Asset public var primaryVariant: Color
 
     /// The color elements presented on top of primary colors should use.
-    public var onPrimary: Color
+    @Asset public var onPrimary: Color
 
     /// An alternate theme color, complimentary to the primary color.
-    public var secondary: Color
+    @Asset public var secondary: Color
 
     /// An optional variant of the secondary theme color.
-    public var secondaryVariant: Color
+    @Asset public var secondaryVariant: Color
 
     /// The color elements presented on top of secondary colors should use.
-    public var onSecondary: Color
+    @Asset public var onSecondary: Color
 
     /// The color that should appear behind scrollable content within the app.
-    public var background: Color
+    @Asset public var background: Color
 
     /// The color elements presented on top of a background should use.
-    public var onBackground: Color
+    @Asset public var onBackground: Color
 
     /// The color used to indicate errors in components.
-    public var error: Color
+    @Asset public var error: Color
 
     /// The color elements presented on top of errors should use.
-    public var onError: Color
+    @Asset public var onError: Color
 
     /// The color used for background colors in components, such as sheets, cards and menus.
-    public var surface: Color
+    @Asset public var surface: Color
 
     /// The color elements presented on top of a surfaces should use.
-    public var onSurface: Color
+    @Asset public var onSurface: Color
 
     /// The color used for drop shadows.
-    public var shadow: Color
+    @Asset public var shadow: Color
 
-    /**
-     * Create a new color theme.
-     * By default, any color omitted here will user the corresponding color in Colors.xcassets
-     *
-     * - Parameters:
-     *  - primary: The color most frequently displayed across components.
-     *  - primaryVariant: An optional variant, or shade, of your primary color.
-     *  - onPrimary: The color elements presented on top of primary colors should use.
-     *  - secondary: An alternate theme color, complimentary to the primary color.
-     *  - secondaryVariant: An optional variant of the secondary theme color.
-     *  - onSecondary: The color elements presented on top of secondary colors should use.
-     *  - background: The color that should appear behind scrollable content within the app.
-     *  - onBackground: The color elements presented on top of a background should use.
-     *  - error: The color used to indicate errors in components.
-     *  - onError: The color elements presented on top of errors should use.
-     *  - surface: The color used for background colors in components, such as sheets, cards and menus.
-     *  - onSurface: The color elements presented on top of a surfaces should use.
-     *  - shadow: The color used for drop shadows.
-     */
-    public init(
-        primary: Color? = nil,
-        primaryVariant: Color? = nil,
-        onPrimary: Color? = nil,
-        secondary: Color? = nil,
-        secondaryVariant: Color? = nil,
-        onSecondary: Color? = nil,
-        background: Color? = nil,
-        onBackground: Color? = nil,
-        error: Color? = nil,
-        onError: Color? = nil,
-        surface: Color? = nil,
-        onSurface: Color? = nil,
-        shadow: Color? = nil
-    ) {
-        self.primary = primary ?? Color("primary", bundle: Bundle.module)
-        self.primaryVariant = primaryVariant ?? Color("primaryVariant", bundle: Bundle.module)
-        self.onPrimary = onPrimary ?? Color("onPrimary", bundle: Bundle.module)
-
-        self.secondary = secondary ?? Color("secondary", bundle: Bundle.module)
-        self.secondaryVariant = secondaryVariant ?? Color("secondaryVariant", bundle: Bundle.module)
-        self.onSecondary = onSecondary ?? Color("onSecondary", bundle: Bundle.module)
-
-        self.background = background ?? Color("background", bundle: Bundle.module)
-        self.onBackground = onBackground ?? Color("onBackground", bundle: Bundle.module)
-
-        self.error = error ?? Color("error", bundle: Bundle.module)
-        self.onError = onError ?? Color("onError", bundle: Bundle.module)
-
-        self.surface = surface ?? Color("surface", bundle: Bundle.module)
-        self.onSurface = onSurface ?? Color("onSurface", bundle: Bundle.module)
-
-        self.shadow = shadow ?? Color("onSurface", bundle: Bundle.module)
-    }
 }

--- a/Sources/NiceComponents/Theme/FontTheme.swift
+++ b/Sources/NiceComponents/Theme/FontTheme.swift
@@ -7,44 +7,25 @@
 //
 
 import SwiftUI
+import NiceInit
 
 /// A collection of styling settings for fonts used throughout components.
-public struct FontTheme {
-    public var screenTitle: FontStyle
-    public var sectionTitle: FontStyle
-    public var itemTitle: FontStyle
+@NiceInit public struct FontTheme {
+    /// The screen title font style to apply.
+    public var screenTitle: FontStyle = FontStyle(size: 48, weight: .semibold)
 
-    public var body: FontStyle
-    public var detail: FontStyle
+    ///The section title font style to apply.
+    public var sectionTitle: FontStyle = FontStyle(size: 34, weight: .semibold)
 
-    public var button: FontStyle
+    ///The item title font style to apply.
+    public var itemTitle: FontStyle = FontStyle(size: 20, weight: .semibold)
 
-    /**
-     * Create a new type theme by providing overrides for any styles you'd like to customize
-     *
-     * - Parameters:
-     *  - screenTitle: The screen title font style to apply. Default is size 48 semibold.
-     *  - sectionTitle: The section title font style to apply. Default is size 34 semibold.
-     *  - itemTitle: The item title font style to apply. Default is size 20 semibold.
-     *  - body: The body type font style to apply. Default is size 16 regular.
-     *  - detail: The body detail type font style to apply. Default is size 14 regular.
-     *  - button: The button font style to apply. Default is size 14 regular.
-     */
-    public init(
-        screenTitle: FontStyle? = nil,
-        sectionTitle: FontStyle? = nil,
-        itemTitle: FontStyle? = nil,
-        body: FontStyle? = nil,
-        detail: FontStyle? = nil,
-        button: FontStyle? = nil
-    ) {
-        self.screenTitle = screenTitle ?? FontStyle(size: 48, weight: .semibold)
-        self.sectionTitle = sectionTitle ?? FontStyle(size: 34, weight: .semibold)
-        self.itemTitle = itemTitle ?? FontStyle(size: 20, weight: .semibold)
+    ///The body type font style to apply.
+    public var body: FontStyle = FontStyle(size: 16)
 
-        self.body = body ?? FontStyle(size: 16)
-        self.detail = detail ?? FontStyle(size: 14)
+    ///The body detail type font style to apply.
+    public var detail: FontStyle = FontStyle(size: 14)
 
-        self.button = button ?? FontStyle(size: 14)
-    }
+    ///The button font style to apply.
+    public var button: FontStyle = FontStyle(size: 14)
 }

--- a/Sources/NiceComponents/Theme/NiceButtonStyle.swift
+++ b/Sources/NiceComponents/Theme/NiceButtonStyle.swift
@@ -32,77 +32,9 @@ import NiceInit
     /// The style of the border applied to your button.
     public var border: NiceBorderStyle = .none
 
-    /**
-     * Create a new button style to apply to a button component.
-     *
-     * - Parameters:
-     *  - fontStyle: Font style to apply to any text in the button. Default is systemFont size 16
-     *  - height: Height of the button. Default is 44.
-     *  - surfaceColor: Surface color of the button.
-     *  - onSurfaceColor: Color of any assets on top of your button.
-     *  - inactiveSurfaceColor: Surface color when set to inactive.  Default is your surface color.
-     *  - inactiveOnSurfaceColor: Color of any assets on top of your button when inactive. Default is your onSurface color.
-     *  - border: Border style for the button. Default is none.
-     *
-     * - Returns: the newly modified button style.
-     */
-    /*
-    public init(
-        fontStyle: FontStyle? = nil,
-        height: CGFloat = 44,
-        surfaceColor: Color,
-        onSurfaceColor: Color,
-        inactiveSurfaceColor: Color? = nil,
-        inactiveOnSurfaceColor: Color? = nil,
-        border: NiceBorderStyle? = nil
-    ) {
-        self.fontStyle = fontStyle ?? .init(size: 16)
-        self.height = height
-        self.surfaceColor = surfaceColor
-        self.onSurfaceColor = onSurfaceColor
-        self.inactiveSurfaceColor = inactiveSurfaceColor ?? surfaceColor
-        self.inactiveOnSurfaceColor = inactiveOnSurfaceColor ?? onSurfaceColor
-        self.border = border ?? .none
-    }
-    */
-
 }
 
-public extension NiceButtonStyle {
-    /**
-     * Modify a button style with the given properties.
-     *
-     * - Parameters:
-     *  - fontStyle: Font style to apply to any text in the button. Default is systemFont size 16
-     *  - height: Height of the button. Default is 44.
-     *  - surfaceColor: Surface color of the button.
-     *  - onSurfaceColor: Color of any assets on top of your button.
-     *  - inactiveSurfaceColor: Surface color when set to inactive.  Default is your background color.
-     *  - inactiveOnSurfaceColor: Color of any assets on top of your button when inactive. Default is your secondary color.
-     *  - border: Border style for the button. Default is none.
-     *
-     * - Returns: the newly modified button style.
-     */
-    func with(
-        fontStyle: FontStyle? = nil,
-        height: CGFloat? = nil,
-        surfaceColor: Color? = nil,
-        onSurfaceColor: Color? = nil,
-        inactiveSurfaceColor: Color? = nil,
-        inactiveOnSurfaceColor: Color? = nil,
-        border: NiceBorderStyle? = nil
-    ) -> NiceButtonStyle {
-        NiceButtonStyle(
-            fontStyle: fontStyle ?? self.fontStyle,
-            height: height ?? self.height,
-            surfaceColor: surfaceColor ?? self.surfaceColor,
-            onSurfaceColor: onSurfaceColor ?? self.onSurfaceColor,
-            inactiveSurfaceColor: inactiveSurfaceColor ?? self.inactiveSurfaceColor,
-            inactiveOnSurfaceColor: inactiveOnSurfaceColor ?? self.inactiveOnSurfaceColor,
-            border: border ?? self.border
-        )
-    }
-}
+
 
 internal extension NiceButtonStyle {
     var paddingToAdd: CGFloat {

--- a/Sources/NiceComponents/Theme/NiceButtonStyle.swift
+++ b/Sources/NiceComponents/Theme/NiceButtonStyle.swift
@@ -24,10 +24,10 @@ import NiceInit
     public var onSurfaceColor: Color
 
     /// Background color when set to inactive.
-    @Default("surfaceColor") public var inactiveSurfaceColor: Color
+    @NiceDefault("surfaceColor") public var inactiveSurfaceColor: Color
 
     /// Content color when set to inactive.
-    @Default("onSurfaceColor") public var inactiveOnSurfaceColor: Color
+    @NiceDefault("onSurfaceColor") public var inactiveOnSurfaceColor: Color
 
     /// The style of the border applied to your button.
     public var border: NiceBorderStyle = .none

--- a/Sources/NiceComponents/Theme/NiceButtonStyle.swift
+++ b/Sources/NiceComponents/Theme/NiceButtonStyle.swift
@@ -7,9 +7,10 @@
 //
 
 import SwiftUI
+import NiceInit
 
 /// A style to be applied to a button component.
-public struct NiceButtonStyle {
+@NiceInit public struct NiceButtonStyle {
     /// The text style will be applied to the text inside the button.
     public var fontStyle: FontStyle
 

--- a/Sources/NiceComponents/Theme/NiceButtonStyle.swift
+++ b/Sources/NiceComponents/Theme/NiceButtonStyle.swift
@@ -24,10 +24,10 @@ import NiceInit
     public var onSurfaceColor: Color
 
     /// Background color when set to inactive.
-    public var inactiveSurfaceColor: Color
+    @Default("surfaceColor") public var inactiveSurfaceColor: Color
 
     /// Content color when set to inactive.
-    public var inactiveOnSurfaceColor: Color
+    @Default("onSurfaceColor") public var inactiveOnSurfaceColor: Color
 
     /// The style of the border applied to your button.
     public var border: NiceBorderStyle = .none

--- a/Sources/NiceComponents/Theme/NiceButtonStyle.swift
+++ b/Sources/NiceComponents/Theme/NiceButtonStyle.swift
@@ -34,8 +34,6 @@ import NiceInit
 
 }
 
-
-
 internal extension NiceButtonStyle {
     var paddingToAdd: CGFloat {
         if let strokeWidth = border.strokeStyle?.lineWidth, strokeWidth > 0.0 {

--- a/Sources/NiceComponents/Theme/NiceButtonStyle.swift
+++ b/Sources/NiceComponents/Theme/NiceButtonStyle.swift
@@ -12,10 +12,10 @@ import NiceInit
 /// A style to be applied to a button component.
 @NiceInit public struct NiceButtonStyle {
     /// The text style will be applied to the text inside the button.
-    public var fontStyle: FontStyle
+    public var fontStyle: FontStyle = FontStyle(size: 16)
 
     /// The height of the button.
-    public var height: CGFloat
+    public var height: CGFloat = 44
 
     /// The background color of the button.
     public var surfaceColor: Color
@@ -30,7 +30,7 @@ import NiceInit
     public var inactiveOnSurfaceColor: Color
 
     /// The style of the border applied to your button.
-    public var border: NiceBorderStyle
+    public var border: NiceBorderStyle = .none
 
     /**
      * Create a new button style to apply to a button component.
@@ -46,6 +46,7 @@ import NiceInit
      *
      * - Returns: the newly modified button style.
      */
+    /*
     public init(
         fontStyle: FontStyle? = nil,
         height: CGFloat = 44,
@@ -63,6 +64,8 @@ import NiceInit
         self.inactiveOnSurfaceColor = inactiveOnSurfaceColor ?? onSurfaceColor
         self.border = border ?? .none
     }
+    */
+
 }
 
 public extension NiceButtonStyle {

--- a/Sources/NiceComponents/Theme/NiceFontStyle.swift
+++ b/Sources/NiceComponents/Theme/NiceFontStyle.swift
@@ -7,45 +7,22 @@
 //
 
 import SwiftUI
+import NiceInit
 
 /// Styling settings for a font.
-public struct FontStyle {
+@NiceInit public struct FontStyle {
     /// The name of the font the text should use.
     public let name: String?
-
-    /// Font weight to use.
-    public let weight: Font.Weight?
 
     /// The size of the text to use.
     public let size: CGFloat
 
+    /// Font weight to use.
+    public let weight: Font.Weight?
+
     /// The space between the characters.
-    public var tracking: CGFloat
-    
+    public var tracking: CGFloat = 0
+
     /// The maximum dynamic type size text should be scaled to.
     public var dynamicTypeMaxSize: DynamicTypeSize?
-
-    /**
-     * Create a new font style.
-     *
-     * - Parameters:
-     *  - name: The name of the font to use.
-     *  - size: The size the font should be.
-     *  - weight: The font weight the font should be. Default is `nil`. TODO: Should this just be regular or something? Need to figure out where it's applied
-     *  - tracking: The space between the characters.
-     *  - dynamicTypeMaxSize: The maximum dynamic type size the font should be scaled to. Default is `nil`, meaning the font will scale to the maximum allowed by iOS.
-     */
-    public init(
-        _ name: String? = nil,
-        size: CGFloat,
-        weight: Font.Weight? = nil,
-        tracking: CGFloat = 0,
-        dynamicTypeMaxSize: DynamicTypeSize? = nil
-    ) {
-        self.name = name
-        self.size = size
-        self.weight = weight
-        self.tracking = tracking
-        self.dynamicTypeMaxSize = dynamicTypeMaxSize
-    }
 }

--- a/Sources/NiceComponents/Theme/NiceTextStyle.swift
+++ b/Sources/NiceComponents/Theme/NiceTextStyle.swift
@@ -7,9 +7,10 @@
 //
 
 import SwiftUI
+import NiceInit
 
 /// Styling settings for a text element.
-public struct NiceTextStyle {
+@NiceInit public struct NiceTextStyle {
     /// The color your text should be.
     public var color: Color
 
@@ -20,59 +21,5 @@ public struct NiceTextStyle {
     public var lineLimit: Int?
 
     /// The space between lines of the text.
-    public var lineSpacing: CGFloat
-    
-    /**
-     * Create a new text style to apply to a text element.
-     *
-     * - Parameters:
-     *  - color: The color your text should be.
-     *  - fontStyle: The font style to apply to the text.
-     *  - lineLimit: The number of lines to limit the text to.
-     */
-    public init(
-        color: Color,
-        fontStyle: FontStyle,
-        lineLimit: Int? = nil,
-        lineSpacing: CGFloat = 0
-    ) {
-        self.color = color
-        self.fontStyle = fontStyle
-        self.lineLimit = lineLimit
-        self.lineSpacing = lineSpacing
-    }
-}
-
-public extension NiceTextStyle {
-    /**
-     * Modify a text style with the given properties.
-     *
-     * - Parameters:
-     *  - color: The color your text should be.
-     *  - size: The font size to change.
-     *  - fontStyle: The font style to apply to the text.
-     *  - lineLimit: The number of lines to limit the text to.
-     *  - lineSpacing: The space between lines of the text.
-     */
-    func with(
-        color: Color? = nil,
-        size: CGFloat? = nil,
-        lineLimit: Int? = nil,
-        lineSpacing: CGFloat? = nil,
-        dynamicTypeMaxSize: DynamicTypeSize? = nil
-        
-    ) -> NiceTextStyle {
-        NiceTextStyle(
-            color: color ?? self.color,
-            fontStyle: FontStyle(
-                self.fontStyle.name,
-                size: size ?? self.fontStyle.size,
-                weight: self.fontStyle.weight,
-                tracking: self.fontStyle.tracking,
-                dynamicTypeMaxSize: dynamicTypeMaxSize ?? self.fontStyle.dynamicTypeMaxSize
-            ),
-            lineLimit: lineLimit ?? self.lineLimit,
-            lineSpacing: lineSpacing ?? self.lineSpacing
-        )
-    }
+    public var lineSpacing: CGFloat = 0
 }

--- a/Sources/NiceInit/NiceInit.swift
+++ b/Sources/NiceInit/NiceInit.swift
@@ -1,4 +1,4 @@
-@attached(member, names: named(init))
+@attached(member, names: named(init), named(with))
 public macro NiceInit() = #externalMacro(module: "NiceInitMacros", type: "NiceInitMacro")
 
 @attached(accessor, names: named(willSet))

--- a/Sources/NiceInit/NiceInit.swift
+++ b/Sources/NiceInit/NiceInit.swift
@@ -1,3 +1,6 @@
 @attached(member, names: named(init))
 public macro NiceInit() = #externalMacro(module: "NiceInitMacros", type: "NiceInitMacro")
 
+@attached(accessor, names: named(willSet))
+public macro Default(_ stringLiteral: String) =
+  #externalMacro(module: "ObservationMacros", type: "ObservationIgnoredMacro")

--- a/Sources/NiceInit/NiceInit.swift
+++ b/Sources/NiceInit/NiceInit.swift
@@ -3,4 +3,8 @@ public macro NiceInit() = #externalMacro(module: "NiceInitMacros", type: "NiceIn
 
 @attached(accessor, names: named(willSet))
 public macro Default(_ stringLiteral: String) =
-  #externalMacro(module: "ObservationMacros", type: "ObservationIgnoredMacro")
+  #externalMacro(module: "NiceInitMacros", type: "DefaultMacro")
+
+@attached(accessor, names: named(willSet))
+public macro Asset() =
+  #externalMacro(module: "NiceInitMacros", type: "AssetMacro")

--- a/Sources/NiceInit/NiceInit.swift
+++ b/Sources/NiceInit/NiceInit.swift
@@ -1,0 +1,3 @@
+@attached(member, names: named(init))
+public macro NiceInit() = #externalMacro(module: "NiceInitMacros", type: "NiceInitMacro")
+

--- a/Sources/NiceInit/NiceInit.swift
+++ b/Sources/NiceInit/NiceInit.swift
@@ -2,9 +2,9 @@
 public macro NiceInit() = #externalMacro(module: "NiceInitMacros", type: "NiceInitMacro")
 
 @attached(accessor, names: named(willSet))
-public macro Default(_ stringLiteral: String) =
+public macro NiceDefault(_ stringLiteral: String) =
   #externalMacro(module: "NiceInitMacros", type: "DefaultMacro")
 
 @attached(accessor, names: named(willSet))
-public macro Asset() =
+public macro NiceAsset() =
   #externalMacro(module: "NiceInitMacros", type: "AssetMacro")

--- a/Sources/NiceInitMacros/NiceInitMacro.swift
+++ b/Sources/NiceInitMacros/NiceInitMacro.swift
@@ -23,15 +23,25 @@ public struct NiceInitMacro: MemberMacro {
         providingMembersOf declaration: some DeclGroupSyntax,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
+        guard let type = declaration.as(StructDeclSyntax.self)?.name.trimmed.description else {
+            throw(MessageError("@NiceInit can only be attached to a struct"))
+        }
+
+        // TODO: this should be filtering out computed properties
         let memberList = declaration.memberBlock.members
 
+        guard !memberList.isEmpty else {
+            throw(MessageError("@NiceInit can only be attached to a type with some stored properties"))
+        }
+
+        // Extract the list of properties to initialize
         let properties = memberList.compactMap { member -> Property? in
             // is a property
             guard
                 let decl = member.decl.as(VariableDeclSyntax.self),
                 let binding = decl.bindings.first,
                 let propertyName = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
-                let propertyType = binding.typeAnnotation?.type
+                let propertyType = binding.typeAnnotation?.type.trimmed // TODO: wont work for declarations without explicit type i.e. ("var foo: Foo = Foo()" will work, but "var foo = Foo()" won't
             else {
                 return nil
             }
@@ -53,39 +63,79 @@ public struct NiceInitMacro: MemberMacro {
             return Property(identifier: propertyName, type: propertyType, hasDefault: hasDefault, attributeDefault: attributeDefault)
         }
 
-        var baseInit: String = "public init(\n"
-        var first: Bool = true
-        for property in properties {
-            if !first {
-                baseInit += ",\n"
-            } else {
-                first = false
-            }
+        var generated: [DeclSyntax] = []
 
-            if property.hasDefault {
-                baseInit += "    \(property.identifier): \(property.type.trimmed)? = nil"
-            } else {
-                baseInit += "    \(property.identifier): \(property.type.trimmed)"
+        // generate the basic memberwise initializer
+        do {
+            var baseInit: String = "public init(\n"
+            var first: Bool = true
+            for property in properties {
+                if !first {
+                    baseInit += ",\n"
+                } else {
+                    first = false
+                }
+
+                if property.hasDefault {
+                    baseInit += "    \(property.identifier): \(property.type)? = nil"
+                } else {
+                    baseInit += "    \(property.identifier): \(property.type)"
+                }
             }
+            baseInit += "\n) {\n"
+            for property in properties {
+                if property.hasDefault, let attributeDefault = property.attributeDefault {
+                    baseInit += "self.\(property.identifier) = \(property.identifier) ?? \(attributeDefault)\n"
+
+                } else if property.hasDefault {
+                    baseInit += "if let _\(property.identifier) = \(property.identifier) { self.\(property.identifier) = _\(property.identifier) }\n"
+
+                } else {
+                    baseInit += "self.\(property.identifier) = \(property.identifier)\n"
+                }
+            }
+            baseInit += "}"
+            generated.append(DeclSyntax(stringLiteral: baseInit))
         }
-        baseInit += "\n) {\n"
-        for property in properties {
-            if property.hasDefault, let attributeDefault = property.attributeDefault {
-                baseInit += "self.\(property.identifier) = \(property.identifier) ?? \(attributeDefault)\n"
 
-            } else if property.hasDefault {
-                baseInit += "if let _\(property.identifier) = \(property.identifier) { self.\(property.identifier) = _\(property.identifier) }\n"
+        // generate the copy-and-modify initializer
+        do {
+            var copyInit: String = "public init(\nwith: \(type)"
 
-            } else {
-                baseInit += "self.\(property.identifier) = \(property.identifier)\n"
+            for property in properties {
+                copyInit += ",\n\(property.identifier): \(property.type)? = nil"
             }
+            copyInit += "\n) {\n"
+            for property in properties {
+                copyInit += "self.\(property.identifier) = \(property.identifier) ?? with.\(property.identifier)\n"
+            }
+            copyInit += "}"
+            generated.append(DeclSyntax(stringLiteral: copyInit))
         }
-        baseInit += "}"
 
-        return [DeclSyntax(stringLiteral: baseInit)]
+        // generate the "create from template" with function"
+        do {
+            var with: String = "public func with(\n"
+
+            with += properties.map {
+                "\($0.identifier): \($0.type)? = nil"
+            }.joined(separator: ",\n")
+
+            with += "\n) -> \(type) {\n\(type)("
+
+            with += properties.map {
+                "\($0.identifier):\($0.identifier) ?? self.\($0.identifier)"
+            }.joined(separator: ",\n")
+
+            with += ")\n}"
+            generated.append(DeclSyntax(stringLiteral: with))
+        }
+
+        return generated
     }
 }
 
+// Empty marker macro, doesn't actually generate any syntax, jsut there so it can be read by the main NiceInitMacro
 public struct DefaultMacro: AccessorMacro {
   public static func expansion<
     Context: MacroExpansionContext,

--- a/Sources/NiceInitMacros/NiceInitMacro.swift
+++ b/Sources/NiceInitMacros/NiceInitMacro.swift
@@ -17,13 +17,39 @@ public struct NiceInitMacro: MemberMacro {
         providingMembersOf declaration: some DeclGroupSyntax,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        [
-            """
-            public init(dummy: Bool) {
-                self.init(surfaceColor: .white, onSurfaceColor: .white)
+        let memberList = declaration.memberBlock.members
+
+        let properties = memberList.compactMap { member -> (String, TypeSyntax)? in
+            // is a property
+            guard
+                let binding = member.decl.as(VariableDeclSyntax.self)?.bindings.first,
+                let propertyName = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+                let propertyType = binding.typeAnnotation?.type
+            else {
+                return nil
             }
-            """
-        ]
+
+            return (propertyName, propertyType)
+        }
+
+        var baseInit: String = "public init(\n"
+        var first: Bool = true
+        for property in properties {
+            if !first {
+                baseInit += ",\n"
+            } else {
+                first = false
+            }
+            
+            baseInit += "    \(property.0): \(property.1)"
+        }
+        baseInit += "\n) {\n"
+        for property in properties {
+            baseInit += "    self.\(property.0) = \(property.0)"
+        }
+        baseInit += "}"
+
+        return [DeclSyntax(stringLiteral: baseInit)]
     }
 }
 

--- a/Sources/NiceInitMacros/NiceInitMacro.swift
+++ b/Sources/NiceInitMacros/NiceInitMacro.swift
@@ -1,0 +1,35 @@
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+struct MessageError: Error, CustomStringConvertible {
+    var description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}
+
+public struct NiceInitMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        [
+            """
+            public init(dummy: Bool) {
+                self.init(surfaceColor: .white, onSurfaceColor: .white)
+            }
+            """
+        ]
+    }
+}
+
+@main
+struct NiceInitPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        NiceInitMacro.self,
+    ]
+}

--- a/Sources/NiceInitMacros/NiceInitMacro.swift
+++ b/Sources/NiceInitMacros/NiceInitMacro.swift
@@ -54,18 +54,18 @@ public struct NiceInitMacro: MemberMacro {
 
             let defaultValue = binding.initializer?.value
             var hasDefault = defaultValue != nil
-            var optional = propertyType.description.last == "?" // TODO: should handle Optional<T> as well
+            let optional = propertyType.description.last == "?" // TODO: should handle Optional<T> as well
             var isColorAsset = false
 
             var attributeDefault: String? = nil
             for element in decl.attributes {
                 if case .attribute(let attribute) = element {
-                    if attribute.attributeName.trimmedDescription == "Default" {
+                    if attribute.attributeName.trimmedDescription == "NiceDefault" {
                         hasDefault = true
                         let arg = attribute.arguments?.as(LabeledExprListSyntax.self)?.first?.as(LabeledExprSyntax.self)?.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue
 
                         attributeDefault = arg
-                    } else if attribute.attributeName.trimmedDescription == "Asset" {
+                    } else if attribute.attributeName.trimmedDescription == "NiceAsset" {
                         if propertyType.description != "Color" {
                             throw(MessageError("@Asset can only be attached to a property of type Color (\(propertyName))"))
                         }

--- a/Sources/NiceInitMacros/NiceInitMacro.swift
+++ b/Sources/NiceInitMacros/NiceInitMacro.swift
@@ -23,6 +23,7 @@ struct Property {
         return isOptional ? type.description : type.description + "?"
     }
 }
+
 public struct NiceInitMacro: MemberMacro {
     public static func expansion(
         of node: AttributeSyntax,
@@ -42,14 +43,17 @@ public struct NiceInitMacro: MemberMacro {
 
         // Extract the list of properties to initialize
         let properties = try memberList.compactMap { member -> Property? in
-            // is a property
             guard
                 let decl = member.decl.as(VariableDeclSyntax.self),
                 let binding = decl.bindings.first,
-                let propertyName = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
-                let propertyType = binding.typeAnnotation?.type.trimmed // TODO: wont work for declarations without explicit type i.e. ("var foo: Foo = Foo()" will work, but "var foo = Foo()" won't
+                let propertyName = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
             else {
                 return nil
+            }
+
+            // TODO: wont work for declarations without explicit type i.e. ("var foo: Foo = Foo()" will work, but "var foo = Foo()" won't
+            guard let propertyType = binding.typeAnnotation?.type.trimmed else {
+                throw(MessageError("@NiceInit currently only supports properties with explicit type annotations"))
             }
 
             let defaultValue = binding.initializer?.value

--- a/Sources/NiceInitMacros/NiceInitMacro.swift
+++ b/Sources/NiceInitMacros/NiceInitMacro.swift
@@ -68,32 +68,27 @@ public struct NiceInitMacro: MemberMacro {
         // generate the basic memberwise initializer
         do {
             var baseInit: String = "public init(\n"
-            var first: Bool = true
-            for property in properties {
-                if !first {
-                    baseInit += ",\n"
-                } else {
-                    first = false
-                }
 
-                if property.hasDefault {
-                    baseInit += "    \(property.identifier): \(property.type)? = nil"
+            baseInit += properties.map {
+                if $0.hasDefault {
+                   "    \($0.identifier): \($0.type)? = nil"
                 } else {
-                    baseInit += "    \(property.identifier): \(property.type)"
+                   "    \($0.identifier): \($0.type)"
                 }
-            }
+            }.joined(separator: ",\n")
+
             baseInit += "\n) {\n"
-            for property in properties {
-                if property.hasDefault, let attributeDefault = property.attributeDefault {
-                    baseInit += "self.\(property.identifier) = \(property.identifier) ?? \(attributeDefault)\n"
 
-                } else if property.hasDefault {
-                    baseInit += "if let _\(property.identifier) = \(property.identifier) { self.\(property.identifier) = _\(property.identifier) }\n"
-
+            baseInit += properties.map {
+                if $0.hasDefault, let attributeDefault = $0.attributeDefault {
+                    "self.\($0.identifier) = \($0.identifier) ?? \(attributeDefault)\n"
+                } else if $0.hasDefault {
+                    "if let _\($0.identifier) = \($0.identifier) { self.\($0.identifier) = _\($0.identifier) }\n"
                 } else {
-                    baseInit += "self.\(property.identifier) = \(property.identifier)\n"
+                    "self.\($0.identifier) = \($0.identifier)\n"
                 }
-            }
+            }.joined()
+
             baseInit += "}"
             generated.append(DeclSyntax(stringLiteral: baseInit))
         }
@@ -102,14 +97,18 @@ public struct NiceInitMacro: MemberMacro {
         do {
             var copyInit: String = "public init(\nwith: \(type)"
 
-            for property in properties {
-                copyInit += ",\n\(property.identifier): \(property.type)? = nil"
-            }
+            copyInit += properties.map {
+                ",\n\($0.identifier): \($0.type)? = nil"
+            }.joined()
+
             copyInit += "\n) {\n"
-            for property in properties {
-                copyInit += "self.\(property.identifier) = \(property.identifier) ?? with.\(property.identifier)\n"
-            }
+
+            copyInit += properties.map {
+                "self.\($0.identifier) = \($0.identifier) ?? with.\($0.identifier)\n"
+            }.joined()
+
             copyInit += "}"
+            
             generated.append(DeclSyntax(stringLiteral: copyInit))
         }
 


### PR DESCRIPTION
All NiceComponents style types currently have very similar and repetitive member-wise initializers and copy functions to let you quickly create styles that are partially default and only have to specify elements that are different from the defaults. This experiments with replacing the hand written version of those with ones generated by Swift macros.

It introduces three new macros:
- `@NiceInit` attach to any struct type to generate the appropriate initializers (a basic member wise init, and copying int that takes a template object and optional parameters for all files, and a `with` function that returns a new type based on the properties of the instance it's called on. If properties are non-optional and don't have default value specified, they will become required parameters to the memberwise `init` (all parameters are optional in the copying `init` and `with` function)
- `@NiceDefault("<some expression>")` can be applied to an individual property in a `@NiceInit` type to add default values that are not representable as initializers in the type declaration (I.e. a field that defaults to the incoming value of another parameter to the initializer)
- `@NiceAsset` can be applied to an individual `Color` property in a `@NiceInit` type to make the default colour come from the asset catalog, using the same name as the property.

Known issues:
- It currently will attempt to generate initialization for computed properties
- It doesn't work if declarations lack an explicit type specifier, i.e. `var foo: Foo = Foo()` will work, but `var foo = Foo()` won't
- Optional values specified as `Optional<T>` rather than `T?` may behave strangely
- It changes the interface of the `with` function on `TextStyle`, that included some parameters that were plumbed through into the `FontStyle` inside it, which can't be generated using a macro, so the with function now jsut takes a font style. Because FontStyle now also has a `with` function being generated (it didn't before), it can be done with minimal additional code, but it doesn't use the exact same interface. 

In spite of those problems I think it's close to ready for production use, since it's intended for use internal to NiceComponents, we can easily just avoid those edge cases (and all of those problems, except the last, I think are fixable relatively easily).

Probably if this is going to be merged, it should be merged alongside the 2.0 work (https://github.com/steamclock/niceComponents/pull/59).