### PR TITLE
Add options to NiceButton to switch between filling available space and sizing to fit contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.1.0]
-- Added `maxWidth` and `textPadding` params to NiceButton constructor to allow for setting buttons to size to fit.
+- Added `horizontalContentPadding` param to NiceButton constructor to allow for setting buttons to size to fit.
+- Fixed an issue that was causing system icons to not work in buttons.
+- Changed default button image sizing from undefined to width: 16, height: 14.
+- Changed default button image padding from 0 to 8.
 
 ## [2.0.4]
 - Added a NiceImage constructor that accepts an `ImageResource` for iOS 17.0 and beyond.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+- Added `maxWidth` and `textPadding` params to NiceButton constructor to allow for setting buttons to size to fit.
+
 ## [2.0.4]
 - Added a NiceImage constructor that accepts an `ImageResource` for iOS 17.0 and beyond.
 

--- a/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
@@ -60,9 +60,9 @@ struct AllComponentsView: View {
                 NiceDivider()
 
                 VStack(alignment: .leading, spacing: 4) {
-                    NiceButton("Primary Button", style: .primary, maxWidth: nil, textPadding: 20) {}
+                    NiceButton("Primary Button", style: .primary, horizontalContentPadding: 20) {}
 
-                    NiceButton("Secondary Button", style: .secondary, maxWidth: nil) {}
+                    NiceButton("Secondary Button", style: .secondary) {}
 
                     NiceButton("Borderless Button", style: .borderless) {}
 

--- a/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
@@ -60,9 +60,9 @@ struct AllComponentsView: View {
                 NiceDivider()
 
                 VStack(alignment: .leading, spacing: 4) {
-                    NiceButton("Primary Button", style: .primary) {}
+                    NiceButton("Primary Button", style: .primary, maxWidth: nil, textPadding: 20) {}
 
-                    NiceButton("Secondary Button", style: .secondary) {}
+                    NiceButton("Secondary Button", style: .secondary, maxWidth: nil) {}
 
                     NiceButton("Borderless Button", style: .borderless) {}
 

--- a/NiceComponentsExample/NiceComponentsExample/View/CustomizingComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/CustomizingComponentsView.swift
@@ -55,6 +55,15 @@ struct CustomizingComponentsView: View {
 
                     NiceButton("Buttons too!", style: .primary.with(surface: .red)) {}
 
+                    NiceButton("System icons on the left", style: .secondary, leftImage: NiceButtonImage(systemIcon: "heart.fill")) {}
+
+                    NiceButton("And the right", style: .secondary, rightImage: NiceButtonImage(systemIcon: "heart")) {}
+
+                    NiceButton("Smaller ones too", style: .secondary, leftImage: NiceButtonImage(systemIcon: "heart.fill", offset: 8), horizontalContentPadding: 20) {}
+
+                    NiceButton("Over here as well", style: .secondary, rightImage: NiceButtonImage(systemIcon: "heart"), horizontalContentPadding: 20) {}
+
+
                     NiceButton("and buttons with images", style: .primary, balanceImages: false) {}
                         .withLeftImage(
                             NiceImage(systemIcon: "fireworks", width: 25, height: 25),

--- a/Sources/NiceComponents/Button/NiceButton.swift
+++ b/Sources/NiceComponents/Button/NiceButton.swift
@@ -16,14 +16,9 @@ public struct NiceButton: View {
     /// The style configuration for the button.
     let style: NiceButtonStyle
 
-    /// Padding between the text and edges of the button. Default is 8.
-    /// Ignored if maxWidth is set, overridden by imageOffsets.
-    var textPadding: CGFloat?
-
-    /// Set max width for the button, dictating if it should fill all available space or not.
-    /// Pass in .infinity to have the button fill all available width, null to have it size to fit.
-    /// Default is .infinity.
-    var maxWidth: CGFloat?
+    /// Padding between the button text/images and edges of the button. Default is 8.
+    /// Set this to `nil` to have the button fill it's available space, like you'd set `maxWidth: .infinity`.
+    var horizontalContentPadding: CGFloat?
 
     /// An optional image to display on the left side of the button.
     var leftImage: NiceButtonImage?
@@ -46,29 +41,28 @@ public struct NiceButton: View {
     ///   - text: The text to display on the button.
     ///   - style: The style configuration for the button.
     ///   - inactive: A Boolean value that determines whether the button is inactive. Defaults to `false`.
+    ///   - balanceImages: A Boolean value indicating whether the images should be balanced. Defaults to `true`.
     ///   - leftImage: An optional image to display on the left side of the button.
     ///   - rightImage: An optional image to display on the right side of the button.
-    ///   - balanceImages: A Boolean value indicating whether the images should be balanced. Defaults to `true`.
+    ///   - horizontalContentPadding: Padding between the button content and edges of the button. Default is nil, causing the button to expand to fill all available space.
     ///   - action: The closure to execute when the button is tapped.
     public init(
         _ text: String,
         style: NiceButtonStyle,
         inactive: Bool = false,
         balanceImages: Bool = true,
-        maxWidth: CGFloat? = .infinity,
         leftImage: NiceButtonImage? = nil,
         rightImage: NiceButtonImage? = nil,
-        textPadding: CGFloat? = 8,
+        horizontalContentPadding: CGFloat? = nil,
         action: @escaping () -> Void
     ) {
         self.text = text
         self.style = style
         self.inactive = inactive
         self.balanceImages = balanceImages
-        self.maxWidth = maxWidth
         self.leftImage = leftImage
         self.rightImage = rightImage
-        self.textPadding = textPadding
+        self.horizontalContentPadding = horizontalContentPadding
         self.action = action
     }
 
@@ -81,7 +75,9 @@ public struct NiceButton: View {
            HStack(spacing: 0) {
                if let leftImage = leftImage {
                    leftImage.image
+                       .padding(.leading, leftImage.offset)
                }
+
                Text(text)
                    .foregroundColor(inactive ? style.colorStyle.inactiveOnSurface : style.colorStyle.onSurface)
                    .scaledFont(
@@ -89,14 +85,15 @@ public struct NiceButton: View {
                        size: style.textStyle.size,
                        weight: style.textStyle.weight,
                        maxSize: style.textStyle.dynamicTypeMaxSize
-                   )
-                   .padding(.leading, leftImage?.offset ?? textPadding ?? 0)
-                   .padding(.trailing, rightImage?.offset ?? textPadding ?? 0)
+                   ).padding(.leading, leftImage?.offset ?? horizontalContentPadding ?? 0)
+                   .padding(.trailing, rightImage?.offset ?? horizontalContentPadding ?? 0)
+
                if let rightImage = rightImage {
                    rightImage.image
+                       .padding(.trailing, rightImage.offset)
                }
            }
-           .frame(maxWidth: maxWidth)
+           .frame(maxWidth: horizontalContentPadding == nil ? .infinity : nil)
        }
        .disabled(inactive)
        .frame(height: style.height)

--- a/Sources/NiceComponents/Button/NiceButton.swift
+++ b/Sources/NiceComponents/Button/NiceButton.swift
@@ -16,6 +16,15 @@ public struct NiceButton: View {
     /// The style configuration for the button.
     let style: NiceButtonStyle
 
+    /// Padding between the text and edges of the button. Default is 8.
+    /// Ignored if maxWidth is set, overridden by imageOffsets.
+    var textPadding: CGFloat?
+
+    /// Set max width for the button, dictating if it should fill all available space or not.
+    /// Pass in .infinity to have the button fill all available width, null to have it size to fit.
+    /// Default is .infinity.
+    var maxWidth: CGFloat?
+
     /// An optional image to display on the left side of the button.
     var leftImage: NiceButtonImage?
 
@@ -45,17 +54,21 @@ public struct NiceButton: View {
         _ text: String,
         style: NiceButtonStyle,
         inactive: Bool = false,
+        balanceImages: Bool = true,
+        maxWidth: CGFloat? = .infinity,
         leftImage: NiceButtonImage? = nil,
         rightImage: NiceButtonImage? = nil,
-        balanceImages: Bool = true,
+        textPadding: CGFloat? = 8,
         action: @escaping () -> Void
     ) {
         self.text = text
         self.style = style
         self.inactive = inactive
+        self.balanceImages = balanceImages
+        self.maxWidth = maxWidth
         self.leftImage = leftImage
         self.rightImage = rightImage
-        self.balanceImages = balanceImages
+        self.textPadding = textPadding
         self.action = action
     }
 
@@ -77,13 +90,13 @@ public struct NiceButton: View {
                        weight: style.textStyle.weight,
                        maxSize: style.textStyle.dynamicTypeMaxSize
                    )
-                   .padding(.leading, leftImage?.offset ?? 0)
-                   .padding(.trailing, rightImage?.offset ?? 0)
+                   .padding(.leading, leftImage?.offset ?? textPadding ?? 0)
+                   .padding(.trailing, rightImage?.offset ?? textPadding ?? 0)
                if let rightImage = rightImage {
                    rightImage.image
                }
            }
-           .frame(maxWidth: .infinity)
+           .frame(maxWidth: maxWidth)
        }
        .disabled(inactive)
        .frame(height: style.height)

--- a/Sources/NiceComponents/Button/NiceButtonImage.swift
+++ b/Sources/NiceComponents/Button/NiceButtonImage.swift
@@ -19,8 +19,8 @@ public struct NiceButtonImage {
     /// Initializes a `NiceButtonImage` with the specified image and offset.
     /// - Parameters:
     ///   - image: The `NiceImage` to be displayed.
-    ///   - offset: The horizontal offset for the image. Defaults to 0.
-    public init(_ image: NiceImage, offset: CGFloat = 0) {
+    ///   - offset: The horizontal offset for the image. Defaults to 8.
+    public init(_ image: NiceImage, offset: CGFloat = 8) {
         self.image = image
         self.offset = offset
     }
@@ -28,19 +28,19 @@ public struct NiceButtonImage {
     /// Initializes a `NiceButtonImage` with an image from a bundle.
     /// - Parameters:
     ///   - bundleString: The string identifier for the image in the bundle.
-    ///   - width: The width of the image. Optional.
-    ///   - height: The height of the image. Optional.
+    ///   - width: Width for the icon. Default is 16.
+    ///   - height: Height for the icon. Default is 14.
     ///   - tintColor: The tint color to apply to the image. Optional.
     ///   - contentMode: The mode that determines how the UI fits the image within its bounds. Defaults to `.fill`.
     ///   - imageAlignment: The alignment of the image within its frame. Defaults to `.center`.
-    ///   - offset: The horizontal offset for the image. Defaults to 0.
+    ///   - offset: The horizontal offset for the image. Defaults to 8.
     public init(_ bundleString: String,
-                width: CGFloat? = nil,
-                height: CGFloat? = nil,
+                width: CGFloat = 16,
+                height: CGFloat = 14,
                 tintColor: Color? = nil,
                 contentMode: SwiftUI.ContentMode = .fill,
                 imageAlignment: Alignment = .center,
-                offset: CGFloat = 0
+                offset: CGFloat = 8
     ) {
         self.init(NiceImage(bundleString, width: width, height: height, tintColor: tintColor, contentMode: contentMode, imageAlignment: imageAlignment), offset: offset)
     }
@@ -48,45 +48,45 @@ public struct NiceButtonImage {
     /// Initializes a `NiceButtonImage` with a system icon.
     /// - Parameters:
     ///   - systemIcon: The system icon name.
-    ///   - width: Optional width for the icon.
-    ///   - height: Optional height for the icon.
+    ///   - width: Width for the icon. Default is 16.
+    ///   - height: Height for the icon. Default is 14.
     ///   - tintColor: Optional tint color for the icon.
     ///   - contentMode: How the UI fits the icon within its bounds. Defaults to `.fill`.
     ///   - imageAlignment: The alignment of the icon within its frame. Defaults to `.center`.
-    ///   - offset: The horizontal offset for the icon. Defaults to 0.
+    ///   - offset: The horizontal offset for the icon. Defaults to 8.
     public init(
         systemIcon: String,
-        width: CGFloat? = nil,
-        height: CGFloat? = nil,
+        width: CGFloat = 16,
+        height: CGFloat = 14,
         tintColor: Color? = nil,
         contentMode: SwiftUI.ContentMode = .fill,
         imageAlignment: Alignment = .center,
-        offset: CGFloat = 0
+        offset: CGFloat = 8
     ) {
-        self.init(NiceImage(systemIcon, width: width, height: height, tintColor: tintColor, contentMode: contentMode, imageAlignment: imageAlignment), offset: offset)
+        self.init(NiceImage(systemIcon: systemIcon, width: width, height: height, tintColor: tintColor, contentMode: contentMode, imageAlignment: imageAlignment), offset: offset)
     }
 
     /// Initializes a `NiceButtonImage` with an image from an URL.
     /// - Parameters:
     ///   - url: The URL of the image. Optional.
-    ///   - width: Optional width for the image.
-    ///   - height: Optional height for the image.
+    ///   - width: Width for the icon. Default is 16.
+    ///   - height: Height for the icon. Default is 14.
     ///   - tintColor: Optional tint color for the image.
     ///   - fallbackImage: A fallback image string identifier to use if the URL image cannot be loaded. Optional.
     ///   - contentMode: How the UI fits the image within its bounds. Defaults to `.fill`.
     ///   - loadingStyle: The style for the activity indicator shown while the image is loading. Optional.
     ///   - imageAlignment: The alignment of the image within its frame. Defaults to `.center`.
-    ///   - offset: The horizontal offset for the image. Defaults to 0.
+    ///   - offset: The horizontal offset for the image. Defaults to 8.
     public init(
         _ url: URL?,
-        width: CGFloat? = nil,
-        height: CGFloat? = nil,
+        width: CGFloat = 16,
+        height: CGFloat = 14,
         tintColor: Color? = nil,
         fallbackImage: String? = nil,
         contentMode: SwiftUI.ContentMode = .fill,
         loadingStyle: UIActivityIndicatorView.Style? = nil,
         imageAlignment: Alignment = .center,
-        offset: CGFloat = 0
+        offset: CGFloat = 8
     ) {
         self.init(NiceImage(url, width: width, height: height, tintColor: tintColor, contentMode: contentMode, imageAlignment: imageAlignment), offset: offset)
     }


### PR DESCRIPTION
This has come up a couple times where it's annoying to have buttons that won't size to fit their contents, so this PR adds two new params to the NiceButton constructor to allow for setting this.

# Breaking changes

- Changed default button image sizing from undefined to width: 16, height: 14.
- Changed default button image padding from 0 to 8.

# Non-breaking changes

Added a new param to the NiceButtonConstructor - `horizontalContentPadding` that allows you to set the padding between the button content and the edges of the button to allow for buttons that won't automatically grow to fit their parent container.

# Bug Fixes

Fix the NiceButtonImage system icon constructor not using the right constructor, meaning you couldn't add system icons

![Screenshot 2024-11-05 at 11 51 21 AM](https://github.com/user-attachments/assets/1edb9d49-6ec0-4aa4-8918-ee017cd88a68)
