### PR TITLE
[69[ Use fixedSize for custom font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1]
+- Fixed custom fonts not applying `NiceTextStyle.dynamicTypeMaxSize`.
+
 ## [2.1.0]
 - Added `horizontalContentPadding` param to NiceButton constructor to allow for setting buttons to size to fit.
 - Fixed an issue that was causing system icons to not work in buttons.

--- a/Sources/NiceComponents/Helper/ScaledFont.swift
+++ b/Sources/NiceComponents/Helper/ScaledFont.swift
@@ -50,7 +50,7 @@ public extension Font {
             scaledSize = min(maxFontSize, scaledSize)
         }
         if let name = name {
-            return Self.custom(name, size: scaledSize).weight(weight ?? .regular)
+            return Self.custom(name, fixedSize: scaledSize).weight(weight ?? .regular)
         }
 
         return Font.system(size: scaledSize, weight:  weight ?? .regular)


### PR DESCRIPTION
The static function `Font.scaledFont(name:size:weight:maxSize)` does scale custom fonts even though `maxSize` is set.

To limit the font to the `maxSize` value, we now call `Font.custom(_: fixedSize:)` which doesn't scale with the dynamic type.

![image](https://github.com/user-attachments/assets/39b2cee9-8950-44be-bd7f-cfd48e11a1de)
